### PR TITLE
Support iconv mime decoder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
         "ericmartel/codeception-email": "^1.0",
         "friendsofphp/php-cs-fixer": "^2.15.0"
     },
+    "suggest": {
+        "ext-iconv": "Will be used as a mime decoder (iconv_mime_decode)",
+        "ext-mbstring": "Will be used as a mime decoder if ext-iconv is not installed (mb_decode_mimeheader)"
+    },
     "autoload": {
         "psr-4": {
             "Codeception\\Module\\": "src"

--- a/src/MailHog.php
+++ b/src/MailHog.php
@@ -459,8 +459,12 @@ class MailHog extends Module
             ) {
                 $property = quoted_printable_decode($property);
             }
-            if (stripos($property, '=?utf-8?Q?') !== false && extension_loaded('mbstring')) {
-                $property = mb_decode_mimeheader($property);
+            if (stripos($property, '=?utf-8?Q?') !== false) {
+                if (extension_loaded('iconv')) {
+                    $property = iconv_mime_decode($property);
+                } elseif (extension_loaded('mbstring')) {
+                    $property = mb_decode_mimeheader($property);
+                }
             }
         }
 


### PR DESCRIPTION
Iconv decoder is doing decode better than mbstring.
For example:
mbstring decode:
Encoded string "=?utf-8?Q?=D0=98=D0=B7=D0=BC=D0=B5=D0=BD=D0=B5=D0=BD=D0=B8?= =?utf-8?Q?=D1=8F_=D0=BF=D0=BE=D1=81=D0=BB=D0=B5_=D1=81=D0=B8=D0=BD=D1=85?= =?utf-8?Q?=D1=80=D0=BE=D0=BD=D0=B8=D0=B7=D0=B0=D1=86=D0=B8?= =?utf-8?Q?=D0=B8_=D0=B0=D0=BA=D1=81=D0=B0=D0=BF=D1=82=D0=B0_=D0=BA=D0=B0?= =?utf-8?Q?=D1=82=D0=B5=D0=B3=D0=BE=D1=80=D0=B8=D0=B9_=D0=BE=D1=82?= 20.07.2020 12:49"
Decoded string: "Изменения_после_синхронизации_аксапта_категорий_от 20.07.2020 12:43"
There are few extra "_" symbols.
But if we look at rfc decoder https://dogmamix.com/MimeHeadersDecoder/ we will see 
"Изменения после синхронизации аксапта категорий от 20.07.2020 12:43"

The same result we get by iconv.

iconv decode: 
Encoded string "=?utf-8?Q?=D0=98=D0=B7=D0=BC=D0=B5=D0=BD=D0=B5=D0=BD=D0=B8?= =?utf-8?Q?=D1=8F_=D0=BF=D0=BE=D1=81=D0=BB=D0=B5_=D1=81=D0=B8=D0=BD=D1=85?= =?utf-8?Q?=D1=80=D0=BE=D0=BD=D0=B8=D0=B7=D0=B0=D1=86=D0=B8?= =?utf-8?Q?=D0=B8_=D0=B0=D0=BA=D1=81=D0=B0=D0=BF=D1=82=D0=B0_=D0=BA=D0=B0?= =?utf-8?Q?=D1=82=D0=B5=D0=B3=D0=BE=D1=80=D0=B8=D0=B9_=D0=BE=D1=82?= 20.07.2020 12:49"
Decoded: "Изменения после синхронизации аксапта категорий от 20.07.2020 12:49"